### PR TITLE
Added support to reference a specified campaign

### DIFF
--- a/includes/commands/class-referral-generate.php
+++ b/includes/commands/class-referral-generate.php
@@ -22,7 +22,10 @@ class Generate_Sub_Command {
 	 * : The affiliate ID or a comma-separated list of affiliate IDs to associate referrals with.
 	 *
 	 * [--status=<referral_status>]
-	 * : The referral status to give generated referrals. If ommitted, statuses will be random.
+	 * : The referral status to give generated referrals. If omitted, statuses will be random.
+	 *
+	 * [--campaign=<campaign>]
+	 * : The campaign to assign generated referrals. If omitted, no campaign will be assigned.
 	 *
 	 * [--format=<format>]
 	 * : Accepted values: progress, ids. Default: ids.
@@ -42,6 +45,7 @@ class Generate_Sub_Command {
 
 		$format = \WP_CLI\Utils\get_flag_value( $assoc_args, 'format', 'progress' );
 		$status = \WP_CLI\Utils\get_flag_value( $assoc_args, 'status',         '' );
+		$campaign = \WP_CLI\Utils\get_flag_value( $assoc_args, 'campaign',     '');
 
 		if ( empty( $assoc_args['affiliate_id'] ) ) {
 			\WP_CLI::error( 'At least one affiliate ID must be specified via --affiliate_id to generate referrals against.' );
@@ -74,6 +78,7 @@ class Generate_Sub_Command {
 					'affiliate_id' => $affiliate_id,
 					'amount'       => $this->random_float( 0, 20 ),
 					'status'       => $status,
+					'campaign'     => $campaign
 				) );
 
 				if ( 'progress' === $format ) {

--- a/includes/commands/class-visit-generate.php
+++ b/includes/commands/class-visit-generate.php
@@ -31,6 +31,9 @@ class Generate_Sub_Command {
 	 * [--with_referral=<yes|no>]
 	 * : Whether to associate a referral with each generated visit. Default 'no'.
 	 *
+	 * [--campaign=<campaign>]
+	 * : The campaign to assign generated referrals. If omitted, no campaign will be assigned.
+	 *
 	 * [--referrer=<URL>]
 	 * : URL to set as the referrer for generated visits. Default is empty (direct).
 	 *
@@ -44,6 +47,9 @@ class Generate_Sub_Command {
 	 *
 	 *     # Generate 2 visits for affiliate ID 20, each with a referral (converted).
 	 *     wp affwp visit generate --count=2 --affiliate_id=20 --with_referral=yes
+	 *
+	 *     # Generate 20 visits for affiliate ID 10, each with a referral (converted).
+	 *     wp affwp visit generate --count=20 --affiliate_id=10 --with_referral=yes
 	 */
 	public function __invoke( $args, $assoc_args ) {
 		$defaults = array(
@@ -54,6 +60,7 @@ class Generate_Sub_Command {
 			'with_referral' => 'no',
 			'visit_url'     => site_url( 'cli' ),
 			'referrer'      => '',
+			'campaign'      => '',
 		);
 
 		$assoc_args = array_merge( $defaults, $assoc_args );
@@ -89,7 +96,8 @@ class Generate_Sub_Command {
 			$args = array(
 				'affiliate_id' => $affiliate_id,
 				'url'          => $assoc_args['visit_url'],
-				'referrer'     => $assoc_args['referrer']
+				'referrer'     => $assoc_args['referrer'],
+				'campaign'     => $assoc_args['campaign']
 			);
 
 			for ( $i = 1; $i <= $assoc_args['count']; $i++ ) {
@@ -104,6 +112,7 @@ class Generate_Sub_Command {
 						'affiliate_id' => $affiliate_id,
 						'amount'       => $this->random_float( 0, 20 ),
 						'status'       => $status,
+						'campaign'     => $assoc_args['campaign']
 					) );
 				}
 


### PR DESCRIPTION
I needed a quick way to scaffold several campaigns with my views, so I went ahead and made this update.

It's important to note that this will probably not work as expected until we update AffiliateWP to 2.2.15, due to this issue: https://github.com/AffiliateWP/AffiliateWP/pull/2878

As such, it may be a good idea to hold off on merging this PR until after AffiliateWP is updated.